### PR TITLE
Use GPIO directory based on actual device tree path

### DIFF
--- a/src/gpio-admin.c
+++ b/src/gpio-admin.c
@@ -27,7 +27,7 @@ static void usage_error(char **argv) {
 
 static void allow_access_by_user(unsigned int pin, const char *filename) {
   char path[PATH_MAX];
-  int size = snprintf(path, PATH_MAX, "/sys/devices/virtual/gpio/gpio%u/%s", pin, filename);
+  int size = snprintf(path, PATH_MAX, "/sys/class/gpio/gpio%u/%s", pin, filename);
   
   if (size >= PATH_MAX) {
     error(7, 0, "path of GPIO pin is too long!");

--- a/src/gpio-admin.c
+++ b/src/gpio-admin.c
@@ -28,7 +28,7 @@ static void usage_error(char **argv) {
 static void allow_access_by_user(unsigned int pin, const char *filename) {
   struct stat info;
   char *sys_path = "/sys/class/gpio/gpio%u/%s";
-  if (stat("/sys/devices/soc", &info) != 0)
+  if (stat("/sys/class/gpio", &info) != 0)
     sys_path = "/sys/devices/virtual/gpio/gpio%u/%s";
 
   char path[PATH_MAX];

--- a/src/gpio-admin.c
+++ b/src/gpio-admin.c
@@ -26,9 +26,14 @@ static void usage_error(char **argv) {
 }
 
 static void allow_access_by_user(unsigned int pin, const char *filename) {
+  struct stat info;
+  char *sys_path = "/sys/class/gpio/gpio%u/%s";
+  if (stat("/sys/devices/soc", &info) != 0)
+    sys_path = "/sys/devices/virtual/gpio/gpio%u/%s";
+
   char path[PATH_MAX];
-  int size = snprintf(path, PATH_MAX, "/sys/class/gpio/gpio%u/%s", pin, filename);
-  
+  int size = snprintf(path, PATH_MAX, sys_path, pin, filename);
+
   if (size >= PATH_MAX) {
     error(7, 0, "path of GPIO pin is too long!");
   }


### PR DESCRIPTION
By testing the device tree directory we can detrermine whether to use the "old" `/sys/devices/virtual/gpio/gpio%u/%s` path or to use the one used after update to kernel 3.18.x: `/sys/class/gpio/gpio%u/%s`, so both configurations are supported.
