### PR TITLE
Update gpio-admin.c

### DIFF
--- a/src/gpio-admin.c
+++ b/src/gpio-admin.c
@@ -27,7 +27,7 @@ static void usage_error(char **argv) {
 
 static void allow_access_by_user(unsigned int pin, const char *filename) {
   char path[PATH_MAX];
-  int size = snprintf(path, PATH_MAX, "/sys/devices/virtual/gpio/gpio%u/%s", pin, filename);
+  int size = snprintf(path, PATH_MAX, "%sgpio%u/%s", GPIO_CLASS_PATH, pin, filename);
   
   if (size >= PATH_MAX) {
     error(7, 0, "path of GPIO pin is too long!");


### PR DESCRIPTION
GPIO path in "allow_access_by_user" function doesn't correspond to new path "/sys/class/gpio/".
With new kernel 3.18, it throw an error when export a pin.